### PR TITLE
changed  column name and the order of migration

### DIFF
--- a/db/migrate/20191126152340_create_stations.rb
+++ b/db/migrate/20191126152340_create_stations.rb
@@ -3,7 +3,7 @@ class CreateStations < ActiveRecord::Migration[5.2]
     create_table :stations do |t|
       t.references :railway, foreign_key: true
       t.string :name, null: false
-      t.integer :station_code, null: false
+      t.integer :odpt_sameAs, null: false, index: true
       t.float :lat, null: false
       t.float :long, null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,11 +58,12 @@ ActiveRecord::Schema.define(version: 2019_11_26_153356) do
   create_table "stations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "railway_id"
     t.string "name", null: false
-    t.integer "station_code", null: false
+    t.integer "odpt_sameAs", null: false
     t.float "lat", null: false
     t.float "long", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["odpt_sameAs"], name: "index_stations_on_odpt_sameAs"
     t.index ["railway_id"], name: "index_stations_on_railway_id"
   end
 


### PR DESCRIPTION
# 概要
stationテーブルのカラム名変更 & インデックス付与
# 目的
カラム名を変えて意味をわかりやすくし、検索速度を向上させるため