### PR TITLE
Add columns to users and avatars

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :this_travel_time, :total_travel_time])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :this_travel_time, :total_travel_time, :start_time, :end_time, :start_pos_lat, :start_pos_long, :end_pos_lat, :end_pos_long, :is_moving])
   end
 end

--- a/db/migrate/20191126080319_devise_create_users.rb
+++ b/db/migrate/20191126080319_devise_create_users.rb
@@ -6,8 +6,16 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       ## Database authenticatable
       t.string :name, null: false, default: "", unique: true
       t.string :email, null: false, default: "", unique: true
+      t.boolean :is_moving, default: false, null: false
+      t.time :start_time
+      t.time :end_time
       t.integer :this_travel_time
       t.integer :total_travel_time
+      t.float :start_pos_lat
+      t.float :start_pos_long
+      t.float :end_pos_lat
+      t.float :end_pos_long
+
       t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable

--- a/db/migrate/20191126095121_create_avatars.rb
+++ b/db/migrate/20191126095121_create_avatars.rb
@@ -12,7 +12,7 @@ class CreateAvatars < ActiveRecord::Migration[5.2]
       t.float :last_location_lat
       t.float :last_location_long
       t.integer :home_station_id, null: false
-
+      t.text :train_timetable
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2019_11_26_153356) do
     t.float "last_location_lat"
     t.float "last_location_long"
     t.integer "home_station_id", null: false
+    t.text "train_timetable"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_avatars_on_user_id"
@@ -74,8 +75,15 @@ ActiveRecord::Schema.define(version: 2019_11_26_153356) do
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "email", default: "", null: false
+    t.boolean "is_moving", default: false, null: false
+    t.time "start_time"
+    t.time "end_time"
     t.integer "this_travel_time"
     t.integer "total_travel_time"
+    t.float "start_pos_lat"
+    t.float "start_pos_long"
+    t.float "end_pos_lat"
+    t.float "end_pos_long"
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"


### PR DESCRIPTION
# 概要
カラムをusersテーブルとavatarsテーブルに追加
# 目的
ユーザーの移動のデータを把握するため。画面遷移があっても移動の情報を保存するため。
# タスク
- users
start_time, end_time, start_pos_lat, start_pos_long, end_pos_lat, end_pos_long, is_moving
- avatars
train_timetable