### PR TITLE
乗換候補路線の配列作成の修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,8 +11,9 @@ class UsersController < ApplicationController
     @station = Station.find(Avatar.find(current_user.avatars[0].id).curr_station_id)
     # to do @positionを取得後、 Avatarのcurr_station_id, curr_lat, curr_long更新
     # ログアウトor終了時に avatarsにlast_station_id
-    @train_timetable = Travel.getCurrentTrainTimetable(@station, "2:00")
-    @position = Travel.getTrainPosition(@train_timetable, "4:00")
+
+    @train_timetable = Travel.getCurrentTrainTimetable(@station, Time.now)
+    @position = Travel.getTrainPosition(@train_timetable, Time.now)
   end
 
   def reload_user

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -18,7 +18,7 @@
 
         #street_refresh
           ここをクリックでストリートビューを表示
-          = @station.odpt_sameAs
+          = @station
           = @train_timetable
           = @position
 

--- a/lib/travel.rb
+++ b/lib/travel.rb
@@ -50,7 +50,7 @@ class Travel
     #入力はlast_stationのid (現在時刻は関数内で使用)
     #①乗換可能な路線一覧をStationAPIで抽出（含 アバタの現在路線）
     result = Odpt::StationAPI.fetch({ "owl:sameAs": station.odpt_sameAs })
-    candidates = result[0]["odpt:connectingRailway"].append(result[0]["odpt:railway"])
+    candidates = [result[0]["odpt:railway"]].append(result[0]["odpt:connectingRailway"])
     possible_railways = []
 
     # railwayテーブルに登録されていて、かつ TrainTimetableを持っている路線だけ選抜
@@ -178,7 +178,7 @@ class Travel
     dep_station = getDepartureStation(station, next_railway)
     # ③入力した時刻以降で次に乗れる電車の列番決定
     train_number = getTrainNumber(dep_station, time)
-    # ④��番��時刻表生成 ([駅名,出発時刻])
+    # ④指定した列番の時刻表生成 ([駅名,出発時刻])
     train_timetable = getTrainTimetable(dep_station, next_railway, train_number)
 
     return train_timetable
@@ -206,7 +206,7 @@ class Travel
         if i == 0
           lat = curr_station.lat
           long = curr_station.long
-        else #座標は現在���と次駅の座標の加重平均を取る
+        else #座標は現在����と次駅の座標の加重平均を取る
           time_c = to_time(train_timetable[i - 1][1])
           time_n = to_time(train_timetable[i][1])
 


### PR DESCRIPTION
# 概要
getNextRailway関数の修正
# 詳細
getNextRailway関数で、乗換候補路線を配列で出力する際、他に乗り換え路線がない駅を引数で入力したときにエラーが起きるのを修正