### PR TITLE
Edit onoff btn

### DIFF
--- a/app/assets/javascripts/travel.js
+++ b/app/assets/javascripts/travel.js
@@ -2,15 +2,15 @@ $(window).on('load', function () {
   $(function () {
     if (document.URL.match('/')) {
 
-      function change_btn(is_moving) {
-        if (is_moving) {
-          $('.start_end_btn').data('btn', 'end');
-          $('.start_end_btn').val('移動終了');
-        } else {
-          $('.start_end_btn').data('btn', 'start');
-          $('.start_end_btn').val('移動開始');
-        };
-      }
+      // function change_btn(is_moving){
+      //   if(is_moving){
+      //     $('.start_end_btn').data('btn','end');
+      //     $('.start_end_btn').val('移動終了');
+      //   }else{
+      //     $('.start_end_btn').data('btn','start');
+      //     $('.start_end_btn').val('移動開始');  
+      //   };
+      // }
 
       function avatar_traveling() {
         $.ajax({
@@ -18,13 +18,13 @@ $(window).on('load', function () {
           url: "users/reload_user",
           dataType: "json"
         })
-          .done(function (user) {
-            console.log(user.is_moving);
-            change_btn(user.is_moving);
-          })
+        .done(function(user){
+          console.log(user.is_moving);
+          // change_btn(user.is_moving);
+        })
       }
-
-      setInterval(avatar_traveling, 60000);
+      
+      // setInterval(avatar_traveling, 1000);
     };
   });
 })

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -18,9 +18,10 @@ $(window).on('load', function(){
             data = { end_pos_lat: lat,
                      end_pos_long: long };
           };
+          url  = "users/" + gon.current_user.id;
           $.ajax({
             type: "PUT",
-            url: "users/reload_user",
+            url: url,
             data: data,
             dataType: "json"
           })
@@ -48,6 +49,7 @@ $(window).on('load', function(){
     function save_now_time(string){
       var now = new Date;
       var data = "";
+      url  = "users/" + gon.current_user.id;
       
       if(string === "start"){
         data = { start_time: now,
@@ -59,7 +61,7 @@ $(window).on('load', function(){
 
       $.ajax({
         type: "PUT",
-        url: "users/reload_user",
+        url: url,
         data: data,
         dataType: "json"
       })

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -25,7 +25,6 @@ $(window).on('load', function(){
             dataType: "json"
           })
           .done(function(){
-            console.log("pos PUT ok");
           });
       },function (error) {
         // エラーコードのメッセージを定義
@@ -65,21 +64,23 @@ $(window).on('load', function(){
         dataType: "json"
       })
       .done(function(){
-        console.log("time PUT ok");
       })
       .fail(function(){
       });
+      return now;
     };
 
 
 
-    function calc_total_time(diff_time){
+    function calc_total_time(end_time){
       // current_userの情報をGETリクエストで取得
       $.ajax({
         type: "GET",
         url: "users/reload_user",
       })
       .done(function(current_user){
+        var diff_time = (end_time - new Date(current_user.start_time))/1000;
+
         url  = "users/" + current_user.id;
         var total_time_base = current_user.total_travel_time;
         var total_time = Math.round(total_time_base) + Math.round(diff_time);
@@ -93,7 +94,6 @@ $(window).on('load', function(){
           dataType: "json"
         })
         .done(function(){
-          console.log("avatar last station PUT ok");
         });
       })
       .fail(function(){
@@ -101,15 +101,11 @@ $(window).on('load', function(){
       });
     }; 
 
-    var start_time = "";
-    var end_time = "";
-
-
     
     $('.start_end_btn').on("click",function(){
 
       // ボタン押下で現在時刻と座標を保存
-      save_now_time($('.start_end_btn').data('btn'));
+      var now_time = save_now_time($('.start_end_btn').data('btn'));
       save_now_pos($('.start_end_btn').data('btn'));
 
       // 「移動開始」ボタンを押したら現在時刻とそれぞれのアバターのlast_station_idを取得
@@ -117,14 +113,12 @@ $(window).on('load', function(){
         $('.start_end_btn').data('btn','end');
         $('.start_end_btn').val('移動終了');
         var now = new Date;
-        // console.log(now);
         var day = now.getDay();
         var hour = now.getHours();
         var minutes = now.getMinutes();
         var wd = ['日', '月', '火', '水', '木', '金', '土']
         start_time = now.getTime();
         $.each(gon.avatars,function(index, avatar){
-          // console.log("start:"+avatar.last_station_id);
         });
       }
       // 「移動終了」ボタンを押したらそれぞれのアバターのcurr_station_idをlast_stationに保存
@@ -133,9 +127,9 @@ $(window).on('load', function(){
         $('.start_end_btn').data('btn','start');
         $('.start_end_btn').val('移動開始');
 
-        var now = new Date;
-        end_time = now.getTime();
-        diff = (end_time - start_time)/1000;
+        // var now = new Date;
+        // end_time = now.getTime();
+        // diff = (end_time - start_time)/1000;
         train_timetable_empty = "";
 
         $.each(gon.avatars,function(index, avatar){
@@ -150,13 +144,12 @@ $(window).on('load', function(){
             dataType: "json"
           })
           .done(function(){
-            console.log("avatar last station PUT ok");
           })
           .fail(function(){
             alert("ユーザ情報の保存に失敗しました。");
           });
 
-          calc_total_time(diff);
+          calc_total_time(now_time);
 
         });
       };

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -6,8 +6,10 @@ $(window).on('load', function(){
       var geo = navigator.geolocation;
 
       geo.getCurrentPosition(function (pos) {
-          var lat = pos.coords.latitude;  //緯度
-          var long = pos.coords.longitude; //経度
+          var lat = "";
+          var long = "";
+          lat = pos.coords.latitude;  //緯度
+          long = pos.coords.longitude; //経度
           var data;
           if(string === "start"){
             data = { start_pos_lat: lat,
@@ -21,6 +23,9 @@ $(window).on('load', function(){
             url: "users/reload_user",
             data: data,
             dataType: "json"
+          })
+          .done(function(){
+            console.log("pos PUT ok");
           });
       },function (error) {
         // エラーコードのメッセージを定義
@@ -34,7 +39,7 @@ $(window).on('load', function(){
         alert(errorMessage[error.code]);
       }, {
         enableHighAccuracy: true,
-        timeout: 6000,
+        timeout: 1000000,
         maximumAge: 1000
       });
     };
@@ -60,10 +65,9 @@ $(window).on('load', function(){
         dataType: "json"
       })
       .done(function(){
-        console.log("PUT ok");
+        console.log("time PUT ok");
       })
       .fail(function(){
-        console.log("PUT ng");
       });
     };
 
@@ -87,6 +91,9 @@ $(window).on('load', function(){
           data: { this_travel_time:  diff_time,
                   total_travel_time: total_time},
           dataType: "json"
+        })
+        .done(function(){
+          console.log("avatar last station PUT ok");
         });
       })
       .fail(function(){
@@ -121,6 +128,7 @@ $(window).on('load', function(){
         });
       }
       // 「移動終了」ボタンを押したらそれぞれのアバターのcurr_station_idをlast_stationに保存
+      // train_timetableを削除
       else{
         $('.start_end_btn').data('btn','start');
         $('.start_end_btn').val('移動開始');
@@ -128,6 +136,7 @@ $(window).on('load', function(){
         var now = new Date;
         end_time = now.getTime();
         diff = (end_time - start_time)/1000;
+        train_timetable_empty = "";
 
         $.each(gon.avatars,function(index, avatar){
           var url = "/avatars/" + avatar.id;
@@ -136,10 +145,12 @@ $(window).on('load', function(){
             url: url,
             data: { last_station_id:    avatar.curr_station_id,
                     last_location_lat:  avatar.curr_location_lat,
-                    last_location_long: avatar.curr_location_long},
+                    last_location_long: avatar.curr_location_long,
+                    train_timetable:    train_timetable_empty},
             dataType: "json"
           })
           .done(function(){
+            console.log("avatar last station PUT ok");
           })
           .fail(function(){
             alert("ユーザ情報の保存に失敗しました。");

--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -34,11 +34,15 @@ class AvatarsController < ApplicationController
     params.require(:avatar).permit(:name, :avatar_type, :stage,
                                    :curr_station_id,    :last_station_id, :home_station_id,
                                    :curr_location_lat,  :last_location_lat,
-                                   :curr_location_long, :last_location_long,).merge(user_id: current_user.id)
+                                   :curr_location_long, :last_location_long).merge(user_id: current_user.id)
   end
 
   def update_params
-    params.permit(:last_station_id, :last_location_lat, :last_location_long)
+    # params.permit(:last_station_id, :last_location_lat, :last_location_long, :tarin_timetable)
+    params.permit(:name, :avatar_type, :stage,
+                  :curr_station_id,    :last_station_id, :home_station_id,
+                  :curr_location_lat,  :last_location_lat,
+                  :curr_location_long, :last_location_long, :train_timetable)
   end
 
 end

--- a/app/views/users/avatars.json.jbuilder
+++ b/app/views/users/avatars.json.jbuilder
@@ -8,4 +8,5 @@ json.array! @avatars do |avatar|
   json.curr_location_long avatar.curr_location_long
   json.last_location_lat  avatar.last_location_lat
   json.last_location_long avatar.last_location_long
+  json.train_timetable    avatar.train_timetable
 end

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -4,7 +4,10 @@
     .right
       .right__movin
         .right__movin__onoff-btn
-          %input{type: 'button', value: '移動開始', data: {btn: 'start'}, class: "start_end_btn btn"}
+          - if current_user.is_moving
+            %input{type: 'button', value: '移動終了', data: {btn: 'end'}, class: "start_end_btn btn"}
+          - else
+            %input{type: 'button', value: '移動開始', data: {btn: 'start'}, class: "start_end_btn btn"}
       .right__user-status
         =link_to 'ユーザ情報変更', edit_user_registration_path(current_user), class: "header__right__left-btn_edit"
     .left


### PR DESCRIPTION
# 概要
「移動開始」「移動終了」押下時の保存内容、およびユーザの移動状態に応じたボタン表示の変化を実装。

# 目的
アバターの移動に際した乗換計算に対応するため。
ページリロードによるボタンとフラグの不一致を回避するため。

# 詳細
- 「移動開始」「移動終了」の表記をhaml読み込み時に判定、分岐
- 「移動終了」押下時にavatarのtrain_timetableを空に更新
- 非同期保存のリクエストのパスを修正
- 移動時間（this_travel_time,total_travel_time）の算出と保存において、ページリロードに影響されない変数に変更

