### PR TITLE
set_ passed_station_when_create_avater

### DIFF
--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -8,6 +8,11 @@ class AvatarsController < ApplicationController
   def create
     @avatar = Avatar.new(avatar_params)
     if @avatar.save
+      stations = Station.select{|s| s.railway[:has_TrainTimetable]==true}
+      stations.each do |station|
+        passed_station = PassedStation.new(avatar_id: @avatar.id, station_id: station.id)
+        passed_station.save
+      end
       redirect_to root_path, notice: "アバターを登録しました"
     else
       render :new


### PR DESCRIPTION
# 概要
新しいアバターが作成された際に、アバターが踏破した駅を保存するためのテーブルに、踏破対象の駅を格納する動作を実装。

# 目的
ユーザへの成果フィードバックのため、アバターが踏破した駅を保存するため。

# 詳細
アバター作成時にpassed_stationsへ、train_timetableをもつ路線のstation_idと、新規作成されたアバターのavatar_idを格納。