### PR TITLE
street_viewとgoogle mapの表示

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -1,4 +1,3 @@
-
 $(function () {
   var map = new Y.Map("map");
   var circle = new Y.Circle(new Y.LatLng(0, 0), new Y.Size(0, 0), { unit: "km", strokeStyle: new Y.Style("99cc99", 2, 0.7), fillStyle: new Y.Style("99cc99", 1, 0.2) })
@@ -50,22 +49,39 @@ $(function () {
   map.addFeature(circle);
 
 
-  // streetビュー　クリックすると表示
-  $("#street_refresh").on("click", function () {
+  ////////////////////////////////////////////
+  //////  google map　クリックすると表示  ////////
+  ///////////////////////////////////////////
+  let gmap = new GMaps({
+    div: '#map', //地図を表示する要素
+    lat: gon.curr_location_lat, //緯度
+    lng: gon.curr_location_long, //軽度
+    zoom: 18 //倍率（1～21）
+  });
+
+  ////////////////////////////////////////////
+  //////  streetビュー　クリックすると表示  ////////
+  ///////////////////////////////////////////
+  $("#panorama--display").on("click", function () {
+    $("#panorama--display").empty()
+    $("#panorama--refresh").append("ストリートビューを更新")
     // 本来はアバターの位置だけど、今は現在地を表示
-    geo.getCurrentPosition(function (pos) {
-      let panorama = GMaps.createPanorama({
-        el: '#street', //ストリートビューを表示する要素
-        lat: pos.coords.latitude, //緯度
-        lng: pos.coords.longitude, //経度
-        zoom: 0, //倍率（0～2）
-        pov: {
-          heading: 120, //水平角
-          pitch: 8 //垂直角
-        }
-      });
+    let panorama = GMaps.createPanorama({
+      el: '#panorama__view', //ストリートビューを表示する要素
+      lat: gon.curr_location_lat, //緯度
+      lng: gon.curr_location_long, //経度
+      zoom: 0, //倍率（0～2）
+      pov: {
+        heading: gon.viewangle, //水平角
+        pitch: 0 //垂直角
+      }
+    });
+    $("#panorama--refresh").on("click", function () {
+      // let latlng = new google.maps.LatLng(35.362456, 138.775202)
+      panorama.setPosition(new google.maps.LatLng(gon.curr_location_lat, gon.curr_location_long));
     });
   })
+  ////////////////////////////////////////////////////
 
 
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,9 +24,13 @@ class UsersController < ApplicationController
       # ③ DB操作
       @avatar.train_timetable = @train_timetable.to_s # 文字列にして時刻表更新
       @avatar.curr_station_id = Station.find_by(odpt_sameAs: @position[0]).id
-      @avatar.curr_location_lat = @position[3]
-      @avatar.curr_location_long = @position[4]
+      @avatar.curr_location_lat = @position[2]
+      @avatar.curr_location_long = @position[3]
       @avatar.save
+
+      gon.curr_location_lat = @position[2]
+      gon.curr_location_long = @position[3]
+      gon.viewangle = @position[4]
       ###############################################
     end
   end

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -19,14 +19,20 @@
           %button#location{style: "position:absolute; top:8px; right:8px; z-index:3; display:none;"}
             start watching
 
-        #street_refresh
-          ここをクリックでストリートビューを表示
-          = @station
-          = @next_railway
-          = @train_timetable
-          = @position
-
-        #street{style: "width:400px; height:200px"}
+        #panorama
+          %a{href: "javascript:void(0)", id: 'panorama--display' }
+            <アバターくん>の視界を表示
+          %a{href: "javascript:void(0)", id: 'panorama--refresh' }
 
 
+
+          #panorama__view{style: "width:400px; height:200px"}
+        アバターの現在駅
+        = @station.odpt_sameAs
+        %br/
+        列車時刻表
+        = @train_timetable
+        %br/
+        現在地
+        = @position
         


### PR DESCRIPTION
# 概要
メインページにアバターの位置を基準にしたmapを表示
# 目的
アバターの移動を可視化するため
# 詳細
- Google map 
ページリロード時にアバターの現在地表示
- street view
更新ボタンクリック時に、アバターの現在位置表示　向いている方角は進行方向
