### PR TITLE
新規登録直後のアバター作成、移動中のログアウト防止

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -81,7 +81,7 @@ $(window).on('load', function () {
     };
 
 
-
+    // ユーザの移動時間を算出、保存
     function calc_total_time(end_time) {
       // current_userの情報をGETリクエストで取得
       $.ajax({
@@ -113,6 +113,32 @@ $(window).on('load', function () {
         });
     };
 
+    function end_travel(now_time) {
+      train_timetable_empty = "";
+
+      calc_total_time(now_time);
+      $.each(gon.avatars, function (index, avatar) {
+        var url = "/avatars/" + avatar.id;
+        $.ajax({
+          type: "PUT",
+          url: url,
+          data: {
+            last_station_id: avatar.curr_station_id,
+            last_location_lat: avatar.curr_location_lat,
+            last_location_long: avatar.curr_location_long,
+            train_timetable: train_timetable_empty
+          },
+          dataType: "json"
+        })
+          .done(function () {
+            console.log("save done");
+          })
+          .fail(function () {
+            alert("ユーザ情報の保存に失敗しました。");
+          });
+      });
+    }
+
 
     $('.start_end_btn').on("click", function () {
       // ボタン押下で現在時刻と座標を保存
@@ -123,50 +149,15 @@ $(window).on('load', function () {
       if ($('.start_end_btn').data('btn') === 'start') {
         $('.start_end_btn').data('btn', 'end');
         $('.start_end_btn').val('移動終了');
-        var now = new Date;
-        var day = now.getDay();
-        var hour = now.getHours();
-        var minutes = now.getMinutes();
-        var wd = ['日', '月', '火', '水', '木', '金', '土']
-        start_time = now.getTime();
-        $.each(gon.avatars, function (index, avatar) {
-        });
       }
       // 「移動終了」ボタンを押したらそれぞれのアバターのcurr_station_idをlast_stationに保存
       // train_timetableを削除
       else {
         $('.start_end_btn').data('btn', 'start');
         $('.start_end_btn').val('移動開始');
-
-        // var now = new Date;
-        // end_time = now.getTime();
-        // diff = (end_time - start_time)/1000;
-        train_timetable_empty = "";
-
-        $.each(gon.avatars, function (index, avatar) {
-          var url = "/avatars/" + avatar.id;
-          $.ajax({
-            type: "PUT",
-            url: url,
-            data: {
-              last_station_id: avatar.curr_station_id,
-              last_location_lat: avatar.curr_location_lat,
-              last_location_long: avatar.curr_location_long,
-              train_timetable: train_timetable_empty
-            },
-            dataType: "json"
-          })
-            .done(function () {
-              console.log("save done");
-            })
-            .fail(function () {
-              alert("ユーザ情報の保存に失敗しました。");
-            });
-
-          calc_total_time(now_time);
-
-        });
+        end_travel(now_time);
       };
     });
+
   });
 });

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -19,17 +19,24 @@
     display:flex;
     padding: 0 20px;
     margin: 0 0 0 auto;
-    &__left-btn_show{
-      margin: 10px;
-      height: 50px;
-      width: 50px;
+    &__left-btn{
       line-height: $header_height;
+
+      &_show{
+        margin: 10px;
+        height: 50px;
+        width: 50px;
+        line-height: $header_height;
+      }
     }
-    &__right-btn_logout{
-      margin: 10px;
-      height: 50px;
-      width: 50px;
+    &__right-btn{
       line-height: $header_height;
+      &_logout{
+        margin: 10px;
+        height: 50px;
+        width: 50px;
+        line-height: $header_height;
+      }
     }
   }
 }

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  def after_sign_up_path_for(resource)
+    # super(resource)
+    new_avatar_path
+  end
+
+  # The path used after sign up for inactive accounts.
+  def after_inactive_sign_up_path_for(resource)
+    # super(resource)
+    new_avatar_path
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -15,8 +15,12 @@ class Users::SessionsController < Devise::SessionsController
 
   # DELETE /resource/sign_out
   def destroy
-    current_user.is_movin
-    super
+    if current_user.is_moving then
+      flash[:alert] = "移動終了してからログアウトしてください。"
+      redirect_to root_path
+    else
+      super 
+    end
   end
 
   # protected

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  def destroy
+    current_user.is_movin
+    super
+  end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -4,10 +4,9 @@
   .header__right
     - if user_signed_in?
       .header__right__left-btn
-        - unless current_page?(root_path(current_user))
+        - unless current_page?(root_path(current_user)) || current_page?( new_avatar_path )
           =link_to 'TOPへ戻る', root_path(current_user), class: "header__right__left-btn_show"
-        - unless current_page?(user_path(current_user))
+        - unless current_page?(user_path(current_user)) || current_page?( new_avatar_path )
           =link_to 'ユーザ情報詳細', user_path(current_user), class: "header__right__left-btn_show"
       .header__right__right-btn
-        =link_to 'ログアウト', destroy_user_session_path, class: "header__right__right-btn_logout",method: :delete
-    
+        = link_to 'ログアウト', destroy_user_session_path, class: "header__right__right-btn_logout",method: :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
-  devise_for :users
+    devise_for :users, :controllers => {
+   :registrations => 'users/registrations',
+   :sessions => 'users/sessions',
+   :passwords => 'users/passwords'
+  }
+  
   root "users#index"
   
   resources :avatars, only: [:new, :create, :edit, :update] do


### PR DESCRIPTION
# 概要
アカウント新規登録直後にアバター作成画面へ遷移する動線を実装。
また、ユーザ移動中はログアウト操作があった場合、メイン画面へのリダイレクトとフラッシュ通知を表示するよう実装。

# 目的
ユーザが必ずアバターを1つ持つよう誘導するため。
また、ユーザがログアウト操作をした際に、必要な情報保存がされないという事態を防止するため。