### PR TITLE
Passed_railwaysテーブルへ正しく保存

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -49,8 +49,8 @@
           .info_key
             = "路線別踏破駅数："
           .value 
-            - Hash[ @passed_rw_st.sort_by{ |_, v| v[2] } ].each do |key, value|
-              = "#{key}: #{value[0]}駅 / 全#{value[1]}駅 "
+            - Hash[ @passed_rw_st.sort_by{ |_, v| v[3] } ].each do |key, value|
+              = "#{key}: #{value[1]}駅 / 全#{value[2]}駅 "
               %br/
     .avatars_infos
       .avatars_infos__header


### PR DESCRIPTION
# 概要
Users#showアクションでpassed_railwayテーブルへ正しく保存するように修正
# 詳細
- 変数の参照間違いを修正
- passed_railwaysテーブルへの重複登録を防ぐ