### PR TITLE
ユーザ移動中（is_moving)の監視の実装

### DIFF
--- a/app/assets/javascripts/travel.js
+++ b/app/assets/javascripts/travel.js
@@ -3,37 +3,30 @@ $(window).on('load', function () {
     if (document.URL.match('/')) {
 
       function avatar_traveling() {
-        $.ajax({
-          type: "GET",
-          url: "/users/reload",
-          dataType: "json"
-        })
-          .done(function (user) {
-            if (user.is_moving) {
-              console.log("is_moving");
-              var url = "/avatars/travel"
+        if ($('#is_moving').length) {
+          console.log("is_moving");
+          var url = "/avatars/travel"
+          $.ajax({
+            type: "GET",
+            url: url,
+            dataType: "json"
+          }) // 場所の確認
+            .done(function () {
               $.ajax({
                 type: "GET",
-                url: url,
+                url: "/avatars/reload",
                 dataType: "json"
-              }) // 場所の確認
-                .done(function () {
-                  $.ajax({
-                    type: "GET",
-                    url: "/avatars/reload",
-                    dataType: "json"
-                  })
-                    .done(function (avatar_info) {
-                      $('#test_curr_timetable').text(avatar_info.timetable);
-                      $('#test_curr_station').text(avatar_info.sta_name);
-                      $('#test_curr_location_lat').text(avatar_info.curr_lat);
-                      $('#test_curr_location_long').text(avatar_info.curr_long);
-                    });
+              })
+                .done(function (avatar_info) {
+                  $('#test_curr_timetable').text(avatar_info.train_timetable);
+                  console.log(avatar_info.train_timetable);
+                  $('#test_curr_station').text(avatar_info.sta_name);
+                  $('#test_curr_location_lat').text(avatar_info.curr_lat);
+                  $('#test_curr_location_long').text(avatar_info.curr_long);
                 });
-            };
-          });
-      };
-
+            });
+        };
+      }
       setInterval(avatar_traveling, 3000);
     };
   });

--- a/app/assets/javascripts/travel.js
+++ b/app/assets/javascripts/travel.js
@@ -12,14 +12,15 @@ $(window).on('load', function () {
             dataType: "json"
           }) // 場所の確認
             .done(function () {
+              console.log("done");
               $.ajax({
                 type: "GET",
                 url: "/avatars/reload",
                 dataType: "json"
               })
                 .done(function (avatar_info) {
-                  $('#test_curr_timetable').text(avatar_info.train_timetable);
-                  console.log(avatar_info.train_timetable);
+                  console.log(avatar_info);
+                  $('#test_curr_timetable').text(avatar_info.timetable);
                   $('#test_curr_station').text(avatar_info.sta_name);
                   $('#test_curr_location_lat').text(avatar_info.curr_lat);
                   $('#test_curr_location_long').text(avatar_info.curr_long);

--- a/app/assets/javascripts/travel.js
+++ b/app/assets/javascripts/travel.js
@@ -12,14 +12,12 @@ $(window).on('load', function () {
             dataType: "json"
           }) // 場所の確認
             .done(function () {
-              console.log("done");
               $.ajax({
                 type: "GET",
                 url: "/avatars/reload",
                 dataType: "json"
               })
                 .done(function (avatar_info) {
-                  console.log(avatar_info);
                   $('#test_curr_timetable').text(avatar_info.timetable);
                   $('#test_curr_station').text(avatar_info.sta_name);
                   $('#test_curr_location_lat').text(avatar_info.curr_lat);

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -56,11 +56,14 @@ $(window).on('load', function () {
       url = "users/" + gon.current_user.id;
 
       if (string === "start") {
+        var html = `<div id="is_moving"></div>`
+        $(".fr").append(html);
         data = {
           start_time: now,
           is_moving: true
         }
       } else {
+        $("#is_moving").remove(html);
         data = {
           end_time: now,
           is_moving: false

--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -68,7 +68,8 @@ class AvatarsController < ApplicationController
 
   def reload
     # avatar複数の時は行をループ
-    values = CSV.read("db/csv/#{current_user.id}_curr.csv")[0]
+    # values = CSV.read("db/csv/#{current_user.id}_curr.csv")[0]
+    values = CSV.read("db/csv/#{current_user.avatars[0].id}_curr.csv")[0]
     # csvの中身をhashに変換
     keys = ["sta_id", "sta_sameAs", "sta_name", "railway", "curr_lat", "curr_long", "n_sta_id", "n_sta_name", "viewangle", "timetable"]
     ary = [keys, values].transpose

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,3 +1,6 @@
+.fr
+  - if current_user.is_moving
+    #is_moving
 .contents
   = render 'layouts/header'
   .devise_form

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,3 +1,6 @@
+.fr
+  - if current_user.is_moving
+    #is_moving
 .contents
   = render 'layouts/header'  
   .devise_form

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,3 +1,6 @@
+.fr
+  - if current_user.is_moving
+    #is_moving
 .contents
   = render 'layouts/header'
   .main

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,6 @@
+.fr
+  - if current_user.is_moving
+    #is_moving
 .contents
   = render 'layouts/header'
   .show


### PR DESCRIPTION
# 概要
ユーザ移動中のフラグ（is_moving）の監視を、非同期通信を使わず実行できるように修正。

# 目的
非同期通信の回数削減と、メインページ以外のページ閲覧中でもアバター移動関数を実行し続けるため。

# 詳細
- フラグis_movingをhtml要素化
- 「移動開始」「移動終了」ボタン押下で要素の追加・削除を実施
- avatars_controllerのcsvファイル読み込み記述におけるファイル名修正