### PR TITLE
Prevent new avatar if enough

### DIFF
--- a/app/assets/javascripts/avatar.js
+++ b/app/assets/javascripts/avatar.js
@@ -100,25 +100,6 @@ $(window).on('load', function () {
       };
     });
 
-    // ここから
-    // $('#change_curr_station').change(function () {
-    //   let home_station_id = $('#home_station_select').val();
-    //   console.log(home_station_id);
-    //   $.each(candidate_stations, function (index, station) {
-    //     if (station.id === Number(home_station_id)) {
-    //       if ($(this).prop('checked')) {
-
-    //         buildSendHome_Station_ID(station, "change");
-    //       } else {
-    //         $('#avatar_curr_station_id').remove();
-    //         $('#avatar_curr_location_lat').remove();
-    //         $('#avatar_curr_location_long').remove();
-    //       }
-    //     }
-    //   });
-    // });
-
-
 
     $('.form__type-select__op__img--1').on("click", function (e) {
       e.preventDefault();

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -36,6 +36,7 @@
     }
 
     &__main{
+      display: flex;
       padding: 10px;
     }
   }

--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -5,7 +5,12 @@ class AvatarsController < ApplicationController
   protect_from_forgery except: :create
 
   def new
-    @avatar = Avatar.new
+    unless current_user.avatars[0] == nil then
+      redirect_to root_path, notice: "すでにアバターを持っています"
+      return
+    else
+      @avatar = Avatar.new
+    end
   end
 
   def create

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,7 +7,7 @@
     .user_infos
       .user_infos__header
         = current_user.name
-        = link_to 'ユーザ情報変更', edit_user_registration_path(current_user), class: "header__right__left-btn_edit"
+        = link_to 'ユーザ情報変更', edit_user_registration_path(current_user), class: "header__left-btn_edit"
       .user_infos__main
         .user_infos_main__infolist
           .info_key
@@ -58,6 +58,7 @@
     .avatars_infos
       .avatars_infos__header
         = current_user.avatars[0].name
+        = link_to 'アバター情報変更', edit_avatar_path(current_user), class: "avatar__header__btn_edit"
       .avatars_infos__main
         .avatars_infos__main__right
 


### PR DESCRIPTION
# 概要
アバター編集画面へのリンク、アバター作成画面への誤遷移防止を実装。

# 目的
ユーザ詳細画面からもアバター編集画面へ遷移できるようにするため。
すでにアバターを持っているユーザが、際限なくアバターを作成するのを防ぐため。

# 詳細
- ユーザ詳細ページへアバター編集画面へのlink_toを記述
- avatars_controllerにてアバター作成画面への遷移を条件文とリダイレクトで対応するよう記述
- ユーザ詳細ページのマップ表示のため、暫定的にscssを編集