### PR TITLE
現在の移動の軌跡を表示

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -22,8 +22,7 @@ $(function () {
     var user_marker;
     var avatar_marker;
     var user_circle;
-    var avatar_latest_pos;
-
+    var polyline;
     ////////////////////////////////////////////
     //////  google map リロードで自動表示  ////////
     ///////////////////////////////////////////
@@ -44,10 +43,9 @@ $(function () {
       }).done(function (avatar_info) {
         gmap.panTo(new google.maps.LatLng(avatar_info.curr_lat, avatar_info.curr_long));
         avatar_marker = add_marker_avatar(gmap, avatar_info.curr_lat, avatar_info.curr_long); // 最初にマーカー
-        avatar_latest_pos = [avatar_info.curr_lat, avatar_info.curr_long] //polyline用
-        console.log('gmap initial')
-        console.log(avatar_info.path)
-
+        polyline = add_polyline(gmap, eval(avatar_info.path));
+        // 軌跡の線描画
+        console.log('gmap initial');
       }).fail(function () {
         alert("地図の表示に失敗しました。")
       });
@@ -104,12 +102,12 @@ $(function () {
           gmap.panTo(new google.maps.LatLng(avatar_info.curr_lat, avatar_info.curr_long));
           // マーカー更新
           gmap.removeMarkers(avatar_marker); //古いの消去
-          avatar_marker = add_marker_avatar(gmap, avatar_info.curr_lat, avatar_info.curr_long); // 新しいマーカー
+          avatar_marker = add_marker_avatar(gmap, avatar_info.curr_lat, avatar_info.curr_long); // 新規
+
           // 軌跡追加
-          path = [avatar_latest_pos, [avatar_info.curr_lat, avatar_info.curr_long]]
-          add_polyline(gmap, path)
-          avatar_latest_pos = [avatar_info.curr_lat, avatar_info.curr_long] //polyline用
-          console.log('gmap done')
+          gmap.removePolylines(polyline); //古いの消去
+          polyline = add_polyline(gmap, eval(avatar_info.path)); //新規
+          console.log('gmap done');
         });
     };
 

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -46,6 +46,8 @@ $(function () {
         avatar_marker = add_marker_avatar(gmap, avatar_info.curr_lat, avatar_info.curr_long); // 最初にマーカー
         avatar_latest_pos = [avatar_info.curr_lat, avatar_info.curr_long] //polyline用
         console.log('gmap initial')
+        console.log(avatar_info.path)
+
       }).fail(function () {
         alert("地図の表示に失敗しました。")
       });

--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -94,15 +94,18 @@ class AvatarsController < ApplicationController
   def reload
     # avatar複数の時は行をループ
     # values = CSV.read("db/csv/#{current_user.id}_curr.csv")[0]
-    values = CSV.read("db/csv/#{current_user.avatars[0].id}_curr.csv")[0]
+    avatar = current_user.avatars[0]
+    values = CSV.read("db/csv/#{avatar.id}_curr.csv")[0]
+    path = CSV.read("db/csv/#{avatar.id}_path.csv")
+    path = path.map { |path| path.map { |path| path.to_f } }.to_s
+    values << path
     # csvの中身をhashに変換
-    keys = ["sta_id", "sta_sameAs", "sta_name", "railway", "curr_lat", "curr_long", "n_sta_id", "n_sta_name", "viewangle", "timetable"]
+    keys = ["sta_id", "sta_sameAs", "sta_name", "railway", "curr_lat", "curr_long", "n_sta_id", "n_sta_name", "viewangle", "timetable", "path"]
     ary = [keys, values].transpose
     avatar_info = Hash[*ary.flatten]
     # hashをjsonにして返す
     render json: avatar_info
   end
-
 
   def edit
     @avatar = Avatar.find(params[:id])

--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -16,17 +16,17 @@ class AvatarsController < ApplicationController
   def create
     @avatar = Avatar.new(avatar_params)
     if @avatar.save
-      stations = Station.select { |s| s.railway[:has_TrainTimetable] == true }
-      stations.each do |station|
-        passed_station = PassedStation.new(avatar_id: @avatar.id, station_id: station.id)
-        passed_station.save
-      end
+      # 拠点駅に選んだ駅を、passed_stationに登録
+      PassedStation.create(avatar_id: @avatar.id, station_id: @avatar.curr_station_id)
 
       # アバター作成時、csvを作成
       sta = Station.find(@avatar.home_station_id)
       empty_timetable = ""
       CSV.open("db/csv/#{@avatar.id}_curr.csv", "w") do |content|
         content << [sta.id, sta.odpt_sameAs, sta.name, sta.railway.jname, sta.lat, sta.long, sta.id, sta.name, 0, empty_timetable]
+      end
+      CSV.open("db/csv/#{@avatar.id}_path.csv", "w") do |content|
+        content << [Station.find(@avatar.curr_station_id).lat, Station.find(@avatar.curr_station_id).long]
       end
 
       redirect_to root_path, notice: "アバターを登録しました"

--- a/app/controllers/travels_controller.rb
+++ b/app/controllers/travels_controller.rb
@@ -1,2 +1,0 @@
-class TravelsController < ApplicationController
-end


### PR DESCRIPTION
# 概要
メイン画面マップにおいて、現在の移動の軌跡をリアルタイムで追跡し描画
# 目的
ユーザーが移動の軌跡を視覚的にわかるようにするため
# 詳細
- アバターの軌跡を座標で記録するX_path.csvの作成
  - アバター新規作成時に拠点駅を記録
  - アバター移動の関数ループ中で、現在駅が更新されたときにその駅の座標を追記していく。
  - アバターの移動は↑で作られた駅を結ぶ座標に、最も最近の座標を加えた配列 ([出発駅、次の駅、次の駅...次の駅、数秒前の座標])を結ぶ軌跡をリアルタイムで描画
  - 移動終了時、curr_station_idに入っている、最も最近通過した駅の座標だけをX_path.csvに残して他を消去し、次の移動の時の軌跡の出発点とする
- アバター新規作成時のpassed_stationへのレコード追加について変更
  - 従来: すべての(avatar_id, station_id)を予め登録
  - 変更: [avatar_id, home_station_id]だけを記録する　他のレコードの追加は通過したときに行う

