### PR TITLE
現在ステータス表示

### DIFF
--- a/app/assets/javascripts/travel.js
+++ b/app/assets/javascripts/travel.js
@@ -48,7 +48,7 @@ $(window).on('load', function () {
                 });
             });
         } else {
-          $('#curr_condition').text(`お休み中です`);
+          $('#curr_condition').text("お休み中です");
           $('#curr_train').text('決まっていません');
         };
       }

--- a/app/assets/javascripts/travel.js
+++ b/app/assets/javascripts/travel.js
@@ -18,17 +18,27 @@ $(window).on('load', function () {
                 dataType: "json"
               })
                 .done(function (avatar_info) {
+                  // 中身 keys = ["sta_id", "sta_sameAs", "sta_name", "railway", "curr_lat", "curr_long", "n_sta_id", "n_sta_name", "viewangle", "timetable", "path"]
                   if (avatar_info.sta_name == avatar_info.n_sta_name) {
                     // 現在駅==次駅 「終点につきました」
-                    $('#test_curr_condition').text(`電車が終点${avatar_info.sta_name}駅につきました。次の電車を探しています。`);
+                    $('#curr_condition').text(`電車が終点${avatar_info.sta_name}駅につきました。次の電車を探しています。`);
+                    $('#curr_train').text('決まっていません')
                   } else {
-                    console.log(eval(avatar_info.timetable)[0][1])
+                    time = (new Date(eval(avatar_info.timetable)[0][1])); // 列車の発車時刻
                     // 電車は決まったがまだ乗っていない 「x駅で◯線を待っている」
+                    if (new Date() < time) {
+                      $('#curr_condition').text(`${avatar_info.sta_name}駅で電車を待っています。`);
+                    } else {
+                      //駅間走行中 「x駅とy駅の間を走っている」
+                      $('#curr_condition').text(`${avatar_info.sta_name}駅から${avatar_info.n_sta_name}駅へ移動中です。`);
+                    }
 
-                    // 駅着時間+10秒以内は「◯◯駅にいます」
+                    //乗っている電車
+                    $('#curr_train').text(`${eval(avatar_info.timetable)[0][2]}駅
+                    ${time.toLocaleTimeString()}発
+                    ${avatar_info.railway}
+                    ${eval(avatar_info.timetable).pop()[2]}駅行き`)
 
-                    //駅間走行中 「x駅とy駅の間を走っている」
-                    $('#test_curr_condition').text(`現在、${avatar_info.sta_name}駅から${avatar_info.n_sta_name}駅に${avatar_info.railway}で移動中`);
                   };
 
                   $('#test_curr_timetable').text(avatar_info.timetable);
@@ -38,7 +48,8 @@ $(window).on('load', function () {
                 });
             });
         } else {
-          $('#test_curr_condition').text(`お休み中です`)
+          $('#curr_condition').text(`お休み中です`);
+          $('#curr_train').text('決まっていません');
         };
       }
       setInterval(avatar_traveling, 10000);

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -166,6 +166,8 @@ $(window).on('load', function () {
         $('.start_end_btn').val('移動終了');
         $('.start_end_btn').removeClass('large_btn_start');
         $('.start_end_btn').addClass('large_btn_end');
+        $('#curr_condition').text("取得中です");
+        $('#curr_train').text('取得中です');
       }
       // 「移動終了」ボタンを押したらそれぞれのアバターのcurr_station_idをlast_stationに保存
       // train_timetableを削除
@@ -174,7 +176,7 @@ $(window).on('load', function () {
         $('.start_end_btn').val('移動開始');
         $('.start_end_btn').addClass('large_btn_start');
         $('.start_end_btn').removeClass('large_btn_end');
-        $('#curr_condition').text(`お休み中です`);
+        $('#curr_condition').text("お休み中です");
         $('#curr_train').text('決まっていません');
         end_travel(now_time);
       };

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -174,6 +174,8 @@ $(window).on('load', function () {
         $('.start_end_btn').val('移動開始');
         $('.start_end_btn').addClass('large_btn_start');
         $('.start_end_btn').removeClass('large_btn_end');
+        $('#curr_condition').text(`お休み中です`);
+        $('#curr_train').text('決まっていません');
         end_travel(now_time);
       };
     });

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -31,9 +31,17 @@
                 .info_value
                   #test_curr_station #{station.name}駅
               %li.infolist
+                .info_key__index
+                  現在
                 .info_value
-                  #test_curr_condition
-                    現在地
+                  #curr_condition
+                    お休み中です
+              %li.infolist
+                .info_key__index
+                  電車
+                .info_value
+                  #curr_train
+                    決まっていません
     .right
       #gmap{style: "width:400px; height:400px; position:relative;"}
         #gmap__option       

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -35,13 +35,19 @@
                   現在
                 .info_value
                   #curr_condition
-                    お休み中です
+                    - if current_user.is_moving
+                      取得中です
+                    - else
+                      お休み中です
               %li.infolist
                 .info_key__index
                   電車
                 .info_value
                   #curr_train
-                    決まっていません
+                    - if current_user.is_moving
+                      取得中です
+                    - else
+                      決まっていません
     .right
       #gmap{style: "width:400px; height:400px; position:relative;"}
         #gmap__option       

--- a/lib/travel.rb
+++ b/lib/travel.rb
@@ -171,11 +171,30 @@ class Travel
       end
     end
 
-    # #⑤時刻を4時間前倒しする (4:00 = 0:00)
-    # train_timetable.each do |t|
-    #   shifted_time = time_shift(t[1].split(":")[0].to_i)
-    #   t[1] = "#{shifted_time.to_i}:" + t[1].split(":")[1]
-    # end
+    
+    # #⑤ 始/終点の日本語駅名挿入 + 時刻をtimeオブジェクトにする
+    l = train_timetable.length-1
+    time_previous = to_time(train_timetable[0][1])
+    train_timetable.each_with_index do |t,i|
+      # 日本語名挿入
+      puts i
+      if i == 0 or i == l
+        t << Station.find_by(odpt_sameAs: t[0]).name
+      else
+        t << "none"
+      end
+      
+      time = to_time(t[1])
+      if time >= time_previous
+        t[1]  = time.to_s
+        time_previous = time
+      else
+        t[1] = (time + 86400).to_s
+        time_previous = time + 86400
+      end
+
+    end     
+    puts train_timetable
 
     return train_timetable
   end


### PR DESCRIPTION
# 概要
メイン画面において、現在の情報を文字で提供する
日付またぎで運行する電車に対応

# 目的
ユーザーが現在のアバターの状況を把握できるようにするため

# 詳細
２つの項目を追加
- 「現在」: 現在の状況
   - 「休んでいます」(移動していない)、
   - 「取得中」(移動中にページをリロードした時など)
   - 「〇〇駅で電車を待っています」(電車は決まっているが出発時刻前)
   - 「〇〇駅からXX駅に移動しています」（電車に乗っている）
   -  「終点〇〇駅につきました。次の電車を探しています。」 ()
- 「電車」 :乗る電車
  - 「決まっていません」（移動していない）
  -  「取得中」（移動開始時、移動中にページをリロード）
  -  「〇〇駅xx:xx発 ◯◯線 〇〇行き」  (電車が決まっている)